### PR TITLE
better omero CLI support

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,5 @@
+${PYTHON} -m pip install . -vv --no-deps --ignore-installed
+
 mkdir OMERO.java-5.6.10-ice36
 unzip $SRC_DIR/OMERO.java-5.6.10-ice36.zip -d $PREFIX/opt/OMERO.java-5.6.10-ice36
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,9 @@
+mkdir OMERO.java-5.6.10-ice36
+unzip $SRC_DIR/OMERO.java-5.6.10-ice36.zip -d $PREFIX/opt/OMERO.java-5.6.10-ice36
+
+# Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
+# This will allow them to be run on environment activation.
+mkdir -p "${PREFIX}/etc/conda/activate.d"
+echo 'export OMERODIR='$PREFIX'/opt/OMERO.java-5.6.10-ice36' > "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh"
+mkdir -p "${PREFIX}/etc/conda/deactivate.d"
+echo 'unset OMERODIR' > "${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}_deactivate.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,11 +16,6 @@ build:
     - omero=omero.main:main
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed
-    - mkdir OMERO.java-5.6.10-ice36
-    - unzip $SRC_DIR/OMERO.java-5.6.10-ice36.zip -d $PREFIX/opt/OMERO.java-5.6.10-ice36
-
-  post_activate:
-    - export OMERODIR=$PREFIX/opt/OMERO.java-5.6.10-ice36
   number: 1
   noarch: python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,6 @@ source:
 build:
   entry_points:
     - omero=omero.main:main
-  script:
-    - {{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed
   number: 1
   noarch: python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,22 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/omero-py-{{ version }}.tar.gz
-  sha256: 339d7c64f34fda3bce4829b3cd768592a15d806e7b17e9ee898e6af231a511a3
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/omero-py-{{ version }}.tar.gz
+    sha256: 339d7c64f34fda3bce4829b3cd768592a15d806e7b17e9ee898e6af231a511a3
+  - url: https://github.com/ome/openmicroscopy/releases/download/v5.6.10/OMERO.java-5.6.10-ice36.zip
+    sha256: 34bd771886904d3227ed6f8109ee120afb4383e42c4cd71c6db1619a4e582008
 
 build:
   entry_points:
     - omero=omero.main:main
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  script:
+    - {{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed
+    - mkdir OMERO.java-5.6.10-ice36
+    - unzip $SRC_DIR/OMERO.java-5.6.10-ice36.zip -d $PREFIX/opt/OMERO.java-5.6.10-ice36
+
+  post_activate:
+    - export OMERODIR=$PREFIX/opt/OMERO.java-5.6.10-ice36
+  number: 1
   noarch: python
 
 requirements:
@@ -33,6 +41,7 @@ requirements:
     - requests
     - urllib3 <2
     - zeroc-ice >=3.6.5,<3.7
+    - openjdk >=8,<17
 
 test:
   imports:
@@ -55,6 +64,7 @@ test:
   commands:
     - pip check
     - omero --help
+    - omero import --help
   requires:
     - pip
 


### PR DESCRIPTION
from the [docs](https://omero.readthedocs.io/en/stable/users/cli/installation.html#installation):

> The import functionality requires a supported version of Java, and some JARs which are automatically downloaded the first time you do an import.

the commit tries to download the JARs directly and set `OMERODIR` as described [here](https://omero.readthedocs.io/en/stable/users/cli/installation.html#omero-py-5-8-0)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
