### PR TITLE
Remove sbesson as a maintainer of the omero-py Conda recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,6 +69,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - sbesson
     - goanpeca
     - joshmoore


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

While I am still heavily involved in the development and maintenance of the upstream project, I am no longer using Conda as part of my workflow. It does not make sense for me to be listed as a maintainer of this recipe and become a reviewer of every Pull Request bumping the version number. This PR updates the metadata file accordingly.

Including a few people in the OME Dundee team who are more heavy users of this recipe and might be interested in taking maintainer responsibilities @jburel @pwalczysko @will-moore

<!--
Please add any other relevant info below:
-->
